### PR TITLE
issue-7-fix-amount-conversion (closes #7)

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,6 @@ df = (
     )
 )
 
-
 # Separate the transactions with normal trx (df1) and GO+ trx (df2)
 df1 = df.loc[lambda x: ~x['Transaction Type'].str.startswith('GO+')]
 df2 = df.loc[lambda x: x['Transaction Type'].str.startswith('GO+')]

--- a/main.py
+++ b/main.py
@@ -40,12 +40,13 @@ df = (
     .drop(['idx', 'Status', 'Reference', 'Details'], axis=1)
     .assign(
         Date=lambda x: pd.to_datetime(x.Date, format=r'%d/%m/%Y'),
-        **
+        **{
             'Amount (RM)': lambda x: x['Amount (RM)'].str.replace('RM', '').str.replace(',', '').astype(float),
             'Wallet Balance': lambda x: x['Wallet Balance'].str.replace('RM', '').str.replace(',', '').astype(float)
         }
     )
 )
+
 
 # Separate the transactions with normal trx (df1) and GO+ trx (df2)
 df1 = df.loc[lambda x: ~x['Transaction Type'].str.startswith('GO+')]

--- a/main.py
+++ b/main.py
@@ -40,9 +40,9 @@ df = (
     .drop(['idx', 'Status', 'Reference', 'Details'], axis=1)
     .assign(
         Date=lambda x: pd.to_datetime(x.Date, format=r'%d/%m/%Y'),
-        **{
-            'Amount (RM)': lambda x: x['Amount (RM)'].str.strip('RM').astype(float),
-            'Wallet Balance': lambda x: x['Wallet Balance'].str.strip('RM').astype(float)
+        **
+            'Amount (RM)': lambda x: x['Amount (RM)'].str.replace('RM', '').str.replace(',', '').astype(float),
+            'Wallet Balance': lambda x: x['Wallet Balance'].str.replace('RM', '').str.replace(',', '').astype(float)
         }
     )
 )


### PR DESCRIPTION
Fixed a ValueError that occurred when converting strings with commas, like "1,000.00", to floats in the 'Amount (RM)' and 'Wallet Balance' columns. This was caused by the presence of commas in the numeric strings.

- Updated the logic to remove commas from 'Amount (RM)' and 'Wallet Balance' before converting them to float.
- Ensured all numeric values are properly handled during conversion, preventing the ValueError.

This resolves the issue where amounts with commas could not be processed correctly.