### PR TITLE
fix-reverse-entry-detection

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,7 +89,11 @@ def check_reverse_entry(df1):
                 ], np.nan)
             }
         )
-        .loc[lambda x: x['Amount (RM)'].isna()][:-1]
+        # Exclude additional legitimate transaction types like PayDirect Payment
+        .loc[lambda x: (
+            x['Amount (RM)'].isna() &
+            ~x['Transaction Type'].str.contains('RFID Payment|eWallet Cash Out|Reload|Transfer to Wallet|DUITNOW|PayDirect Payment', na=False)
+        )][:-1]
         .index
         .to_list()
     )


### PR DESCRIPTION
…t and RFID payments

Fixes an issue where legitimate transactions such as PayDirect Payments, RFID Payments, Reloads, and eWallet Cash Outs with a zero balance were incorrectly flagged as reverse entries. Updated the logic to exclude these transaction types from reverse entry detection.

- Excluded 'PayDirect Payment', 'RFID Payment', 'Reload', 'eWallet Cash Out', 'Transfer to Wallet', and 'DUITNOW' transactions with a zero balance.
- Refined reverse entry detection logic to ensure only invalid entries are flagged.

This resolves the issue of legitimate transactions being mistakenly identified as problematic.