### PR TITLE
Allow pdf to be passed as arg instead of needing to store into pdf/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ pdf/tng_ewallet_transactions*.pdf
 pdf/transactions*.pdf
 csv/tng_ewallet_transactions*.csv
 missing_data/missing_data.csv
+/*.pdf
 
 # Ignore folder for virtual environment.
 /*venv


### PR DESCRIPTION
PR for lazy people like me who just want to paste PDF directly into root instead of paste into `pdf/` folder 😎 Can use like this:

<img width="951" alt="image" src="https://github.com/user-attachments/assets/225836df-932e-45a0-8e26-cb98ff2119a2">

  

Maybe in the future also no need to paste into project root ady, can just run this script on Downloads/ folder, see how lo

---

### Key changes made:

1. Added a new `get_pdf_path()` function that:

    - Checks if a PDF file path is provided as a command-line argument
    - Falls back to the original behavior if no argument is provided
    - Validates that the file exists


2. Modified the file path handling:

    - Now generates the CSV filename based on the input PDF filename
    - Added automatic creation of required directories (csv, missing_data)


3. Added better error handling and user feedback:

    - Prints success message with input and output paths
    - Shows clear error messages if something goes wrong


You can now use the script in two ways:

1. Original way (putting file in pdf/ folder):

```bash
python main.py
```

2. New way (directly specifying the PDF):

```bash
python main.py tng_ewallet_transactions.pdf
```

Both methods will work, and the script will create the necessary directories if they don't exist. The output CSV will be saved in the `csv/` directory with a timestamp appended to avoid overwriting existing files.